### PR TITLE
Fix thread pool shutdown without timeout

### DIFF
--- a/main_final.py
+++ b/main_final.py
@@ -197,7 +197,8 @@ class InvoiceBot:
         # 等待线程池中的任务完成
         self.logger.info("等待处理任务完成...")
         try:
-            self.thread_pool.shutdown(wait=True, timeout=30)
+            # 等待所有任务完成并关闭线程池
+            self.thread_pool.shutdown(wait=True)
             self.logger.info("所有处理任务已完成")
         except Exception as e:
             self.logger.error(f"关闭线程池时出错: {e}")


### PR DESCRIPTION
## Summary
- remove `timeout` argument from thread pool shutdown
- clarify log message about waiting for all tasks

## Testing
- `python -m py_compile main_final.py`
- `python test_env.py` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6847e27e6fc4832aac47e964f557c64f